### PR TITLE
Improve registration fees table

### DIFF
--- a/registration.html
+++ b/registration.html
@@ -3,22 +3,43 @@ layout: default
 title: Registration
 ---
 
+<p>We look forward to welcoming you to FOGA&nbsp;2025 in Leiden. The fees
+  for attending the conference are listed below.</p>
+
 <h2>Registration Fees</h2>
-<table>
+<table class="table table-striped">
   <thead>
-    <tr><th>Category</th><th>Fee</th></tr>
+    <tr>
+      <th>Category</th>
+      <th>Early</th>
+      <th>Late</th>
+    </tr>
   </thead>
   <tbody>
-    <tr><td>Non-member Student Early</td><td>&euro;270</td></tr>
-    <tr><td>Non-member Student Late</td><td>&euro;380</td></tr>
-    <tr><td>Student or retired member early</td><td>&euro;215</td></tr>
-    <tr><td>Student or retired member late</td><td>&euro;325</td></tr>
-    <tr><td>Member Early</td><td>&euro;385</td></tr>
-    <tr><td>Member Late</td><td>&euro;495</td></tr>
-    <tr><td>Non-Member Early</td><td>&euro;440</td></tr>
-    <tr><td>Non-Member Late</td><td>&euro;550</td></tr>
+    <tr>
+      <td>Student or retired member</td>
+      <td>&euro;215</td>
+      <td>&euro;325</td>
+    </tr>
+    <tr>
+      <td>Member</td>
+      <td>&euro;385</td>
+      <td>&euro;495</td>
+    </tr>
+    <tr>
+      <td>Non-member student</td>
+      <td>&euro;270</td>
+      <td>&euro;380</td>
+    </tr>
+    <tr>
+      <td>Non-member</td>
+      <td>&euro;440</td>
+      <td>&euro;550</td>
+    </tr>
   </tbody>
 </table>
 
-<p>The registration system will open after July 10, 2025.</p>
-<p>The early bird deadline is July 20, 2025.</p>
+<div class="alert alert-info" role="alert">
+  <p class="mb-0">The registration system will open after July&nbsp;10, 2025.</p>
+  <p class="mb-0">The early bird deadline is July&nbsp;20, 2025.</p>
+</div>


### PR DESCRIPTION
## Summary
- restructure registration fees into early/late columns
- add intro text for registration section
- highlight registration opening information in a notice box

## Testing
- `make build`

------
https://chatgpt.com/codex/tasks/task_e_6862823433c88321b6bd1d187a74439d