### PR TITLE
Update ROAR-net meeting info

### DIFF
--- a/registration.html
+++ b/registration.html
@@ -43,3 +43,8 @@ title: Registration
   <p class="mb-0">The registration system is open: <a target="_blank" href="https://cvent.me/yNE7vZ">Register here!</a></p>
   <p class="mb-0">The early bird deadline is July&nbsp;20, 2025.</p>
 </div>
+
+<p>
+  If you wish to join the ROAR-net meeting on August&nbsp;26, you can sign up
+  for it directly within the FOGA registration form.
+</p>

--- a/roarnet.md
+++ b/roarnet.md
@@ -3,16 +3,31 @@ layout: default
 title: Informal ROAR-NET Meeting
 ---
 
-
 Join us for a workshop-style networking event for everyone interested in the <a href="https://roar-net.eu/" target="_blank">ROAR-NET COST action</a>, taking place just before the FOGA 2025 conference!
 
 ## Event Details
 
-- **Date:** Tuesday, August 26, 2025  
-- **Time:** 9:30 AM - 5:30 PM  
+- **Date:** Tuesday, August 26, 2025
+- **Time:** 9:30 AM - 5:30 PM
 - **Location:** Conference venue, room TBA
 
-The event will feature plenary and working group sessions, interactive activities, and opportunities to network with other members of the ROAR-NET COST action as well as researchers interested in its topics.
-Consider joining us a day in advance!
+The event will feature plenary and working group sessions, interactive activities, and opportunities to network with other members of the ROAR-NET COST action as well as researchers interested in its topics. Consider joining us a day in advance!
+
+On Tuesday, August 26 (the day preceding the FOGA conference), we will host an informal meeting of the <a target="_blank" href="https://roar-net.eu/">COST action ROAR-net</a>, with the following program:
+
+- 9:30-12:00 meeting and discussion with all participants
+- 12:00-13:30 lunch break and networking
+- 13:30-17:00 WG meetings (participants can freely choose which working group meeting they want to join, and they can switch between different WGs at their convenience)
+
+List of participating working groups (list to be confirmed, details about the working groups are available <a href="https://roar-net.eu/wg/">here</a>.):
+
+| WG number | WG title                                   | Contact person      |
+|-----------|--------------------------------------------|---------------------|
+| 1         | Problem modelling and user experience      | Luca Di Gaspero     |
+| 2         | Mixed continuous and discrete optimisation | Jose Madeira        |
+| 3         | Single- and multiobjective optimisation    | Kathrin Klamroth    |
+| 4         | Optimisation under uncertainty             | Per Kristian Lehre  |
+| 5         | Algorithm selection and configuration      | Carola Doerr        |
+| 6         | Benchmarking                               | Boris Naujoks       |
 
 For more information about ROAR-NET COST action, visit the <a href="https://roar-net.eu/" target="_blank">ROAR-NET COST action website</a>.


### PR DESCRIPTION
## Summary
- note that the ROAR‑net meeting registration is part of the FOGA form
- expand the `roarnet.md` page with schedule and participating working groups

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687174f128a883218926307e82d9064b